### PR TITLE
Added option to disable one or more ad networks before initialization and more

### DIFF
--- a/Runtime/Adapters/Banner/BannerAdAdapter.cs
+++ b/Runtime/Adapters/Banner/BannerAdAdapter.cs
@@ -1,3 +1,4 @@
+using AppodealStack.Monetization.Api;
 using Veittech.Modules.Ad.SMAI_Appodeal.Common;
 
 namespace Veittech.Modules.Ad.SMAI_Appodeal
@@ -14,5 +15,38 @@ namespace Veittech.Modules.Ad.SMAI_Appodeal
         public abstract void Destroy();
 
         public abstract void Hide();
+
+        public abstract void Cache();
+
+        protected void Cache(int adType)
+        {
+            if (!Appodeal.IsAutoCacheEnabled(adType))
+            {
+                Appodeal.Cache(adType);
+            }
+        }
+
+        public abstract bool IsLoaded();
+
+        protected bool IsLoaded(int adType, string placement)
+        {
+            var adLoader = new AdLoader(adType, placement);
+
+            if (adLoader.IsReadyBanner())
+            {
+                return true;
+            }
+
+            return false;
+        }
+
+        public abstract double GetPredictedEcpm();
+
+        public abstract double GetPredictedEcpm(string placement);
+
+        protected double GetPredictedEcpm(int adType, string placement)
+        {
+            return Appodeal.GetPredictedEcpmForPlacement(adType, placement);
+        }
     }
 }

--- a/Runtime/Adapters/Banner/ClassicBannerAdAdapter.cs
+++ b/Runtime/Adapters/Banner/ClassicBannerAdAdapter.cs
@@ -34,5 +34,25 @@ namespace Veittech.Modules.Ad.SMAI_Appodeal
         {
             Appodeal.Destroy(AD_TYPE);
         }
+
+        public sealed override void Cache()
+        {
+            Cache(AD_TYPE);
+        }
+
+        public sealed override bool IsLoaded()
+        {
+            return IsLoaded(AD_TYPE, AdPlacements.DEFAULT);
+        }
+
+        public sealed override double GetPredictedEcpm()
+        {
+            return GetPredictedEcpm(AD_TYPE, AdPlacements.DEFAULT);
+        }
+
+        public sealed override double GetPredictedEcpm(string placemen)
+        {
+            return GetPredictedEcpm(AD_TYPE, placemen);
+        }
     }
 }

--- a/Runtime/Adapters/Banner/CustomBannerAdAdapter.cs
+++ b/Runtime/Adapters/Banner/CustomBannerAdAdapter.cs
@@ -1,9 +1,13 @@
 using AppodealStack.Monetization.Api;
+using AppodealStack.Monetization.Common;
+using Veittech.Modules.Ad.SMAI_Appodeal.Common;
 
 namespace Veittech.Modules.Ad.SMAI_Appodeal
 {
     public sealed class CustomBannerAdAdapter : BannerAdAdapter
     {
+        private const int AD_TYPE = AppodealAdType.Banner;
+
         private readonly int _horizontalPosition;
         private readonly int _verticalPosition;
 
@@ -26,6 +30,26 @@ namespace Veittech.Modules.Ad.SMAI_Appodeal
         public sealed override void Destroy()
         {
             Hide();
+        }
+
+        public sealed override void Cache()
+        {
+            Cache(AD_TYPE);
+        }
+
+        public sealed override bool IsLoaded()
+        {
+            return IsLoaded(AD_TYPE, AdPlacements.DEFAULT);
+        }
+
+        public sealed override double GetPredictedEcpm()
+        {
+            return GetPredictedEcpm(AD_TYPE, AdPlacements.DEFAULT);
+        }
+
+        public sealed override double GetPredictedEcpm(string placemen)
+        {
+            return GetPredictedEcpm(AD_TYPE, placemen);
         }
     }
 }

--- a/Runtime/Adapters/Banner/MrecAdAdapter.cs
+++ b/Runtime/Adapters/Banner/MrecAdAdapter.cs
@@ -1,9 +1,13 @@
 using AppodealStack.Monetization.Api;
+using AppodealStack.Monetization.Common;
+using Veittech.Modules.Ad.SMAI_Appodeal.Common;
 
 namespace Veittech.Modules.Ad.SMAI_Appodeal
 {
     public sealed class MrecAdAdapter : BannerAdAdapter
     {
+        private const int AD_TYPE = AppodealAdType.Mrec;
+
         private readonly int _horizontalPosition;
         private readonly int _verticalPosition;
 
@@ -26,6 +30,26 @@ namespace Veittech.Modules.Ad.SMAI_Appodeal
         public sealed override void Destroy()
         {
             Hide();
+        }
+
+        public sealed override void Cache()
+        {
+            Cache(AD_TYPE);
+        }
+
+        public sealed override bool IsLoaded()
+        {
+            return IsLoaded(AD_TYPE, AdPlacements.DEFAULT);
+        }
+
+        public sealed override double GetPredictedEcpm()
+        {
+            return GetPredictedEcpm(AD_TYPE, AdPlacements.DEFAULT);
+        }
+
+        public sealed override double GetPredictedEcpm(string placemen)
+        {
+            return GetPredictedEcpm(AD_TYPE, placemen);
         }
     }
 }

--- a/Runtime/Adapters/Video/InterstitialAdAdapter.cs
+++ b/Runtime/Adapters/Video/InterstitialAdAdapter.cs
@@ -1,4 +1,5 @@
 using AppodealStack.Monetization.Common;
+using Veittech.Modules.Ad.SMAI_Appodeal.Common;
 
 namespace Veittech.Modules.Ad.SMAI_Appodeal
 {
@@ -15,6 +16,21 @@ namespace Veittech.Modules.Ad.SMAI_Appodeal
         public sealed override void Cache()
         {
             Cache(AD_TYPE);
+        }
+
+        public sealed override bool IsLoaded()
+        {
+            return IsLoaded(AD_TYPE, AdPlacements.DEFAULT);
+        }
+
+        public sealed override double GetPredictedEcpm()
+        {
+            return GetPredictedEcpm(AD_TYPE, AdPlacements.DEFAULT);
+        }
+
+        public sealed override double GetPredictedEcpm(string placemen)
+        {
+            return GetPredictedEcpm(AD_TYPE, placemen);
         }
     }
 }

--- a/Runtime/Adapters/Video/RewardedAdAdapter.cs
+++ b/Runtime/Adapters/Video/RewardedAdAdapter.cs
@@ -48,5 +48,20 @@ namespace Veittech.Modules.Ad.SMAI_Appodeal
 
             AppodealCallbacks.RewardedVideo.OnFinished -= GiveRewardAfterWatch;
         }
+
+        public sealed override bool IsLoaded()
+        {
+            return IsLoaded(AD_TYPE, AdPlacements.DEFAULT);
+        }
+
+        public sealed override double GetPredictedEcpm()
+        {
+            return GetPredictedEcpm(AD_TYPE, AdPlacements.DEFAULT);
+        }
+
+        public sealed override double GetPredictedEcpm(string placemen)
+        {
+            return GetPredictedEcpm(AD_TYPE, placemen);
+        }
     }
 }

--- a/Runtime/Adapters/Video/VideoAdAdapter.cs
+++ b/Runtime/Adapters/Video/VideoAdAdapter.cs
@@ -19,9 +19,7 @@ namespace Veittech.Modules.Ad.SMAI_Appodeal
                 placement = AdPlacements.DEFAULT;
             }
 
-            var adLoader = new AdLoader(adType, placement);
-
-            if (!adLoader.IsReadyAd())
+            if (!IsLoaded())
             {
                 return;
             }
@@ -37,6 +35,29 @@ namespace Veittech.Modules.Ad.SMAI_Appodeal
             {
                 Appodeal.Cache(adType);
             }
+        }
+
+        public abstract bool IsLoaded();
+
+        protected bool IsLoaded(int adType, string placement)
+        {
+            var adLoader = new AdLoader(adType, placement);
+
+            if (adLoader.IsReadyAd())
+            {
+                return true;
+            }
+
+            return false;
+        }
+
+        public abstract double GetPredictedEcpm();
+
+        public abstract double GetPredictedEcpm(string placemen);
+
+        protected double GetPredictedEcpm(int adType, string placement)
+        {
+            return Appodeal.GetPredictedEcpmForPlacement(adType, placement);
         }
     }
 }

--- a/Runtime/Base/IBannerAd.cs
+++ b/Runtime/Base/IBannerAd.cs
@@ -3,11 +3,17 @@ namespace Veittech.Modules.Ad.SMAI_Appodeal.Common
     public interface IBannerAd
     {
         void Show();
-
         void Show(string placement);
 
         void Destroy();
 
         void Hide();
+
+        void Cache();
+
+        bool IsLoaded();
+
+        double GetPredictedEcpm();
+        double GetPredictedEcpm(string placement);
     }
 }

--- a/Runtime/Base/IVideoAd.cs
+++ b/Runtime/Base/IVideoAd.cs
@@ -3,9 +3,13 @@ namespace Veittech.Modules.Ad.SMAI_Appodeal.Common
     public interface IVideoAd
     {
         void Show();
-
         void Show(string placement);
 
         void Cache();
+
+        bool IsLoaded();
+
+        double GetPredictedEcpm();
+        double GetPredictedEcpm(string placement);
     }
 }

--- a/Runtime/Base/IVideoAdWithReward.cs
+++ b/Runtime/Base/IVideoAdWithReward.cs
@@ -2,7 +2,7 @@ using System;
 
 namespace Veittech.Modules.Ad.SMAI_Appodeal.Common
 {
-    public interface IVideoAdWithReward
+    public interface IVideoAdWithReward : IVideoAd
     {
         void Show(string placement, Action rewardCallback);
 

--- a/Runtime/Common/Enums/AppodealAdNetworks.cs
+++ b/Runtime/Common/Enums/AppodealAdNetworks.cs
@@ -1,0 +1,28 @@
+namespace Veittech.Modules.Ad.SMAI_Appodeal.Common
+{
+    public enum AppodealAdNetworks
+    {
+        a4g,
+        adcolony,
+        admob,
+        admob_mediation,
+        applovin,
+        appodeal,
+        bidmachine,
+        bidon,
+        bigo_ads,
+        dt_exchange,
+        gam,
+        inmobi,
+        ironsource,
+        facebook,
+        mintegral,
+        mraid,
+        my_target,
+        notsy,
+        unity_ads,
+        vast,
+        vungle,
+        yandex
+    }
+}

--- a/Runtime/Common/Enums/AppodealAdNetworks.cs.meta
+++ b/Runtime/Common/Enums/AppodealAdNetworks.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c247832e047b7ab4993e99e6d3133aee
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Configs/AdConfigAdapter.cs
+++ b/Runtime/Configs/AdConfigAdapter.cs
@@ -1,20 +1,30 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
 using AppodealStack.Monetization.Api;
 using AppodealStack.Monetization.Common;
+using Veittech.Modules.Ad.SMAI_Appodeal.Utils;
 
 namespace Veittech.Modules.Ad.SMAI_Appodeal.Common
 {
     public sealed class AdConfigAdapter
     {
-        public string AndroidAppKey { get; private set; }
-        public string IOSAppKey { get; private set; }
+        public bool IsInitialized { get; private set; }
+        public bool IsTestMode { get; private set; }
+
         public int AdTypes { get; private set; }
 
-        public bool IsTestMode { get; private set; }
+        public string AndroidAppKey { get; private set; }
+        public string IOSAppKey { get; private set; }
+
         public bool SafeArea { get; private set; }
         public bool MuteVideoAd {get; private set; }
+        public bool ChildDirectedTreatment { get; private set; }
+
         public bool AutoCacheInterstitialAd { get; private set; }
         public bool AutoCacheRewardedAd { get; private set; }
-        public bool ChildDirectedTreatment { get; private set; }
+        public bool AutoCacheBannerAd { get; private set; }
+        public bool AutoCacheMrecAd { get; private set; }
 
         public bool BannerAnimation { get; private set; }
         public bool SmartBanners { get; private set; }
@@ -22,41 +32,58 @@ namespace Veittech.Modules.Ad.SMAI_Appodeal.Common
 
         public AppodealLogLevel LogLevel { get; private set; }
 
+        public IReadOnlyList<string> DisabledNetworksNames { get; private set; }
+        public IReadOnlyList<AppodealAdNetworks> DisabledNetworks { get; private set; }
+
         private AdConfigAdapter(Builder builder)
         {
+            this.IsInitialized = builder.IsInitialized;
+            this.IsTestMode = builder.IsTestMode;
+            this.AdTypes = builder.AdTypes;
             this.AndroidAppKey = builder.AndroidAppKey;
             this.IOSAppKey = builder.IOSAppKey;
-            this.AdTypes = builder.AdTypes;
-            this.IsTestMode = builder.IsTestMode;
             this.MuteVideoAd = builder.MuteVideoAd;
             this.SafeArea = builder.SafeArea;
+            this.ChildDirectedTreatment = builder.ChildDirectedTreatment;
             this.AutoCacheInterstitialAd = builder.AutoCacheInterstitialAd;
             this.AutoCacheRewardedAd = builder.AutoCacheRewardedAd;
-            this.ChildDirectedTreatment = builder.ChildDirectedTreatment;
+            this.AutoCacheBannerAd = builder.AutoCacheBannerAd;
+            this.AutoCacheMrecAd = builder.AutoCacheMrecAd;
             this.SmartBanners = builder.SmartBanners;
             this.TabletBanner = builder.TabletBanner;
             this.BannerAnimation = builder.BannerAnimation;
             this.LogLevel = builder.LogLevel;
+            this.DisabledNetworks = builder.DisabledNetworks;
+            this.DisabledNetworksNames = builder.DisabledNetworksNames;
         }
 
         public sealed class Builder
         {
+            internal bool IsInitialized { get; private set; }
+            internal bool IsTestMode { get; private set; }
+
+            internal int AdTypes { get; private set; }
+
             internal string AndroidAppKey { get; private set; }
             internal string IOSAppKey { get; private set; }
-            internal int AdTypes { get; private set; }
-            internal bool IsTestMode { get; private set; }
 
             internal bool SafeArea { get; private set; }
             internal bool MuteVideoAd { get; private set; }
+            internal bool ChildDirectedTreatment { get; private set; }
+
             internal bool AutoCacheInterstitialAd { get; private set; }
             internal bool AutoCacheRewardedAd { get; private set; }
-            internal bool ChildDirectedTreatment { get; private set; }
+            internal bool AutoCacheBannerAd { get; private set; }
+            internal bool AutoCacheMrecAd { get; private set; }
 
             internal bool BannerAnimation { get; private set; }
             internal bool SmartBanners { get; private set; }
             internal bool TabletBanner { get; private set; }
 
             internal AppodealLogLevel LogLevel { get; private set; }
+
+            internal List<string> DisabledNetworksNames { get; private set; }
+            internal List<AppodealAdNetworks> DisabledNetworks { get; private set; }
 
             public Builder(string androidAppKey, int adTypes)
             {
@@ -123,6 +150,24 @@ namespace Veittech.Modules.Ad.SMAI_Appodeal.Common
                 return this;
             }
 
+            public Builder WithAutoCacheBannerAd()
+            {
+                this.AutoCacheBannerAd = true;
+
+                Appodeal.SetAutoCache(AppodealAdType.Banner, this.AutoCacheBannerAd);
+
+                return this;
+            }
+
+            public Builder WithAutoCacheMrecAd()
+            {
+                this.AutoCacheMrecAd = true;
+
+                Appodeal.SetAutoCache(AppodealAdType.Mrec, this.AutoCacheMrecAd);
+
+                return this;
+            }
+
             public Builder WithBannerAnimation()
             {
                 this.BannerAnimation = true;
@@ -159,6 +204,48 @@ namespace Veittech.Modules.Ad.SMAI_Appodeal.Common
                 return this;
             }
 
+            public Builder WithDisableAdNetwork(AppodealAdNetworks network)
+            {
+                DisabledNetworks.Add(network);
+
+                SMAIAppodealUtils.AdTools.DisableNetwork(network);
+
+                return this;
+            }
+
+            public Builder WithDisableNetworks(AppodealAdNetworks[] networks)
+            {
+                foreach (var network in networks)
+                {
+                    DisabledNetworks.Add(network);
+                }
+
+                SMAIAppodealUtils.AdTools.DisableNetworks(networks);
+
+                return this;
+            }
+
+            public Builder WithDisableNetwork(string networkName)
+            { 
+                DisabledNetworksNames.Add(networkName);
+
+                SMAIAppodealUtils.AdTools.DisableNetwork(networkName);
+
+                return this;
+            }
+
+            public Builder WithDisableNetworks(string[] networksNames)
+            {
+                foreach (var networkName in networksNames)
+                {
+                    DisabledNetworksNames.Add(networkName);
+                }
+
+                SMAIAppodealUtils.AdTools.DisableNetworks(networksNames);
+
+                return this;
+            }
+
             public AdConfigAdapter Build()
             {
                 Appodeal.SetTesting(IsTestMode);
@@ -170,6 +257,47 @@ namespace Veittech.Modules.Ad.SMAI_Appodeal.Common
 #endif
 
                 return new AdConfigAdapter(this);
+            }
+
+            public AdConfigAdapter Build(Action<bool, List<string>> initializationFinished)
+            {
+                AppodealCallbacks.Sdk.OnInitialized += 
+                    (sender, sdkInitializeArgs) =>
+                    {
+                        InitializationFinished(sender, sdkInitializeArgs);
+
+                        if (sdkInitializeArgs.Errors.Count < 1)
+                        {
+                            initializationFinished?.Invoke(true, sdkInitializeArgs.Errors);
+
+                            return;
+                        }
+
+                        initializationFinished?.Invoke(false, sdkInitializeArgs.Errors);
+                    };
+
+                Build();
+
+                return new AdConfigAdapter(this);
+            }
+
+            private void InitializationFinished(object sender,
+                SdkInitializedEventArgs sdkInitializedArgs)
+            {
+                AppodealCallbacks.Sdk.OnInitialized -= InitializationFinished;
+
+                if (sdkInitializedArgs.Errors.Count < 1)
+                {
+                    IsInitialized = true;
+
+                    return;
+                }
+
+                foreach (var item in sdkInitializedArgs.Errors)
+                {
+                    Debug.LogError($"[SMAI APPODEAL] Appodeal SDK initialization" +
+                        $" did not complete successfully, the reasons are as follows: {item}");
+                }
             }
         }
     }

--- a/Runtime/Utils/SMAIAppodealUtils.cs
+++ b/Runtime/Utils/SMAIAppodealUtils.cs
@@ -1,0 +1,42 @@
+using AppodealStack.Monetization.Api;
+using Veittech.Modules.Ad.SMAI_Appodeal.Common;
+
+namespace Veittech.Modules.Ad.SMAI_Appodeal.Utils
+{
+    public static class SMAIAppodealUtils
+    {
+        public sealed class AdTools
+        {
+            public static void DisableNetworks(string[] networksNames)
+            {
+                foreach (var network in networksNames)
+                {
+                    DisableNetwork(network);
+                }
+            }
+
+            public static void DisableNetwork(string networkName)
+            {
+                Appodeal.DisableNetwork(networkName);
+            }
+
+            public static void DisableNetwork(AppodealAdNetworks network)
+            {
+                DisableNetwork(network.ToString());
+            }
+
+            public static void DisableNetworks(AppodealAdNetworks[] networks)
+            {
+                foreach(var network in networks)
+                {
+                    DisableNetwork(network);
+                }
+            }
+
+            public static void ShowDebugTestAd()
+            {
+                Appodeal.ShowTestScreen();
+            }
+        }
+    }
+}

--- a/Runtime/Utils/SMAIAppodealUtils.cs.meta
+++ b/Runtime/Utils/SMAIAppodealUtils.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: aed7d6ac6afb1764daaf9d2e41743d3f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Added option to activate autocaching for all types of banners. 
Added option  to get the current ad loading status (for all ad types). 
Added option to track current Ecpm value for each ad type.

[Refactoring] Extended capabilities of `IVideoAdWithReward` interface by copying functionality of `IVideoAd` interface. 
[Refactoring] Added overload to the `Build(Action<bool, List<string>> initCallback)` method, with the ability to track the current status of Appodeal SDK initialization.